### PR TITLE
fix: release-drafterがプッシュされたタグ名でドラフトを作成するように設定を修正

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,9 +2,9 @@
 # Configuration for Release Drafter: https://github.com/release-drafter/release-drafter
 
 # Name template for the release draft
-name-template: 'v$NEXT_PATCH_VERSION'
+name-template: '$RESOLVED_VERSION'
 # Tag template for the release draft
-tag-template: 'v$NEXT_PATCH_VERSION'
+tag-template: '$RESOLVED_VERSION'
 
 # Categories for Conventional Commits
 categories:


### PR DESCRIPTION
GitHub Actionsのリリースワークフローで `release not found` エラーが発生する問題を修正します。

`.github/release-drafter.yml` の設定を変更し、`release-drafter` がプッシュされたタグ名 (`$RESOLVED_VERSION`) を使ってドラフトを作成するようにしました。