### PR TITLE
Fix: GitHub Actions リリースワークフローの失敗を解決

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,14 +42,14 @@ jobs:
       - name: Generate Changelog with git-cliff
         uses: orhun/git-cliff-action@v3
         id: git-cliff # ステップIDを設定 (オプション)
-         with:
-           config: cliff.toml # 設定ファイルを指定
-           args: --latest # ★変更: --latest のみ指定
-         env:
-           OUTPUT: RELEASE_NOTES.md # ★変更: env.OUTPUT で出力ファイルを指定
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # リポジトリ情報取得に必要
+        with:
+          config: cliff.toml # 設定ファイルを指定
+          args: --latest
+        env:
+          OUTPUT: RELEASE_NOTES.md # ★変更: env.OUTPUT で出力ファイルを指定
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # リポジトリ情報取得に必要
 
-       # ★ 変更点なし: 生成された RELEASE_NOTES.md を使用
+      # ★ 変更点なし: 生成された RELEASE_NOTES.md を使用
       - name: Create GitHub Release and Upload Artifact
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,28 +6,20 @@ on:
       - 'v*.*.*' # vで始まるタグがプッシュされたときに実行
 
 jobs:
-  draft_release:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # to create release drafts
-      pull-requests: read # to read pull request information
-    steps:
-      - name: Draft release notes
-        uses: release-drafter/release-drafter@v6
-        with:
-          config-name: release-drafter.yml # Use our custom config
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # draft_release ジョブは削除
 
   build-and-release:
-    needs: draft_release # Wait for the draft to be created
+    # needs: draft_release は削除
     runs-on: ubuntu-latest # 実行環境
     permissions:
-      contents: write # リリース編集・アセットアップロードのために必要
+      contents: write # リリース作成・アセットアップロードのために必要
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        # オプション: チェンジログ生成のために全履歴を取得
+        with:
+          fetch-depth: 0
 
       - name: Setup Deno
         uses: denoland/setup-deno@v2
@@ -46,34 +38,27 @@ jobs:
       - name: Build single HTML file
         run: deno task release:build
 
-      - name: Check if release draft exists # ★追加: リリース存在確認ステップ
-        id: check_release
+      # ★ 追加: git-cliff をインストール
+      - name: Install git-cliff
+        run: |
+          curl -Ls https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          echo "$PWD" >> $GITHUB_PATH # Add current dir to PATH to find git-cliff
+
+      # ★ 追加: git-cliff でリリースノートを生成
+      - name: Generate Changelog
+        id: generate_changelog
+        run: |
+          git-cliff --output RELEASE_NOTES.md ${{ github.ref_name }}
+          echo "Generated RELEASE_NOTES.md"
+
+      # ★ 変更点: gh release create を使用してリリース作成とアセットアップロード
+      - name: Create GitHub Release and Upload Artifact
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if gh release view ${{ github.ref_name }}; then
-            echo "Release draft found."
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "Release draft NOT found for tag ${{ github.ref_name }}!"
-            echo "exists=false" >> $GITHUB_OUTPUT
-            # 必要に応じてここでワークフローを失敗させることも可能
-            # exit 1
-          fi
+          gh release create ${{ github.ref_name }} \
+            --title "Release ${{ github.ref_name }}" \
+            --notes-file RELEASE_NOTES.md \
+            ./dist/tanshu3.html # アップロードするアセット
 
-      - name: Edit GitHub Release and Upload Artifact
-        if: steps.check_release.outputs.exists == 'true' # ★追加: リリースが存在する場合のみ実行
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # 自動的に提供されるトークン
-        run: |
-          # リリースを公開状態にする (ドラフト解除)
-          gh release edit ${{ github.ref_name }} --draft=false
-          # ビルド成果物をアップロード
-          gh release upload ${{ github.ref_name }} ./dist/tanshu3.html
-          echo "Release ${{ github.ref_name }} published and tanshu3.html artifact uploaded."
-
-      - name: Handle missing release draft
-        if: steps.check_release.outputs.exists == 'false'
-        run: |
-          echo "::error::Release draft for tag ${{ github.ref_name }} was not found. Please check the 'draft_release' job logs and the release-drafter configuration."
-          exit 1 # ワークフローを失敗させる
+          echo "Release ${{ github.ref_name }} created and tanshu3.html artifact uploaded."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,14 +42,14 @@ jobs:
       - name: Generate Changelog with git-cliff
         uses: orhun/git-cliff-action@v3
         id: git-cliff # ステップIDを設定 (オプション)
-        with:
-          config: cliff.toml # 設定ファイルを指定
-          args: -o RELEASE_NOTES.md --tag ${{ github.ref_name }} # 出力ファイルと対象タグを指定
-        env:
-          # OUTPUT: RELEASE_NOTES.md # with.args で出力ファイルを指定するため不要な場合が多い
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # リポジトリ情報取得に必要
+         with:
+           config: cliff.toml # 設定ファイルを指定
+           args: --latest # ★変更: --latest のみ指定
+         env:
+           OUTPUT: RELEASE_NOTES.md # ★変更: env.OUTPUT で出力ファイルを指定
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # リポジトリ情報取得に必要
 
-      # ★ 変更点なし: 生成された RELEASE_NOTES.md を使用
+       # ★ 変更点なし: 生成された RELEASE_NOTES.md を使用
       - name: Create GitHub Release and Upload Artifact
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,23 @@ jobs:
       - name: Build single HTML file
         run: deno task release:build
 
+      - name: Check if release draft exists # ★追加: リリース存在確認ステップ
+        id: check_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view ${{ github.ref_name }}; then
+            echo "Release draft found."
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Release draft NOT found for tag ${{ github.ref_name }}!"
+            echo "exists=false" >> $GITHUB_OUTPUT
+            # 必要に応じてここでワークフローを失敗させることも可能
+            # exit 1
+          fi
+
       - name: Edit GitHub Release and Upload Artifact
+        if: steps.check_release.outputs.exists == 'true' # ★追加: リリースが存在する場合のみ実行
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # 自動的に提供されるトークン
         run: |
@@ -55,3 +71,9 @@ jobs:
           # ビルド成果物をアップロード
           gh release upload ${{ github.ref_name }} ./dist/tanshu3.html
           echo "Release ${{ github.ref_name }} published and tanshu3.html artifact uploaded."
+
+      - name: Handle missing release draft
+        if: steps.check_release.outputs.exists == 'false'
+        run: |
+          echo "::error::Release draft for tag ${{ github.ref_name }} was not found. Please check the 'draft_release' job logs and the release-drafter configuration."
+          exit 1 # ワークフローを失敗させる

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,20 +38,18 @@ jobs:
       - name: Build single HTML file
         run: deno task release:build
 
-      # ★ 追加: git-cliff をインストール
-      - name: Install git-cliff
-        run: |
-          curl -Ls https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-x86_64-unknown-linux-gnu.tar.gz | tar xz
-          echo "$PWD" >> $GITHUB_PATH # Add current dir to PATH to find git-cliff
+      # ★ 変更点: orhun/git-cliff-action を使用してリリースノートを生成
+      - name: Generate Changelog with git-cliff
+        uses: orhun/git-cliff-action@v3
+        id: git-cliff # ステップIDを設定 (オプション)
+        with:
+          config: cliff.toml # 設定ファイルを指定
+          args: -o RELEASE_NOTES.md --tag ${{ github.ref_name }} # 出力ファイルと対象タグを指定
+        env:
+          # OUTPUT: RELEASE_NOTES.md # with.args で出力ファイルを指定するため不要な場合が多い
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # リポジトリ情報取得に必要
 
-      # ★ 追加: git-cliff でリリースノートを生成
-      - name: Generate Changelog
-        id: generate_changelog
-        run: |
-          git-cliff --output RELEASE_NOTES.md ${{ github.ref_name }}
-          echo "Generated RELEASE_NOTES.md"
-
-      # ★ 変更点: gh release create を使用してリリース作成とアセットアップロード
+      # ★ 変更点なし: 生成された RELEASE_NOTES.md を使用
       - name: Create GitHub Release and Upload Artifact
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   # draft_release ジョブは削除
-
   build-and-release:
     # needs: draft_release は削除
     runs-on: ubuntu-latest # 実行環境

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,61 @@
+# cliff.toml
+# Configuration for git-cliff: https://github.com/orhun/git-cliff
+
+[changelog]
+# Changelog header
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.\n
+"""
+# Changelog body template
+# Uses Conventional Commits types for grouping
+body = """
+{% if version %}\
+    ## [{{ version }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}(**{{ commit.scope }}**) {% endif %}{{ commit.message | upper_first }} ([`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/31103/tanshu3/commit/{{ commit.id }}))\
+    {% endfor %}
+{% endfor %}\n
+"""
+# Remove trailing newline from the body
+trim = true
+# Changelog footer
+footer = ""
+
+[git]
+# Parse commits based on Conventional Commits specification
+conventional_commits = true
+# Filter out commits that are not conventional
+filter_unconventional = true
+# Process commits starting from the latest tag
+latest_tag_only = false
+# Sort commits by date
+sort_commits = "newest"
+# Tag pattern for version comparison
+tag_pattern = "v[0-9]*"
+# Skip tags that are not semantic versions
+skip_tags = ""
+# Ignore tags that match the given regex
+ignore_tags = ""
+
+# Define commit groups based on Conventional Commits types
+# Matches the categories from release-drafter.yml
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug Fixes" },
+  { message = "^test", group = "Testing" },
+  { message = "^chore", group = "Miscellaneous Tasks"},
+  { message = "^ci", group = "Continuous Integration"},
+  { message = "^build", group = "Build System"},
+  { message = "^refactor", group = "Code Refactoring"},
+  { message = "^perf", group = "Performance Improvements"},
+  { message = "^style", group = "Style"},
+  { message = "^revert", group = "Reverts"},
+  { message = "^docs", group = "Documentation" },
+  { body = ".*security", group = "Security" }, # Example: Detect security related commits
+]

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -89,6 +89,11 @@ _このドキュメントは、プロジェクトの現在の状態、完了し�
   - **[完了]** リリースノート生成設定 (`.github/release-drafter.yml`) 作成。
   - **[完了]** `README.md` 更新。
   - **[完了]** Memory Bank 更新 (`systemPatterns.md`, `techContext.md`, `activeContext.md`, `progress.md`)。
+- **[完了] GitHub Actions リリースワークフロー修正:**
+  - `release-drafter` を `git-cliff` と `orhun/git-cliff-action` に置き換え。
+  - `cliff.toml` 設定ファイルを追加。
+  - タグプッシュ時に `git-cliff` でリリースノートを生成し、`gh release create` でリリースを作成するように `.github/workflows/release.yml` を修正。
+  - 関連するエラー（`release not found`, `body is too long`, YAML 構文エラー）を解決。
 - **リリース自動化 (旧):** (CI/CD 推進計画に統合・強化)
   - **[完了]** 単一HTML生成スクリプト (`scripts/release.ts`) 作成。
   - **[完了]** `deno.jsonc` に `release:build` タスク追加。
@@ -143,6 +148,9 @@ _このドキュメントは、プロジェクトの現在の状態、完了し�
 
 - **[2025-04-10]:** 短手３判定ロジック修正（加算除外）。「他の手術」判定時に、診療明細名称に「加算」を含むものを除外するように `evaluator.ts` を修正。関連テスト (`evaluator_test.ts`) を追加。
 - **[2025-04-08]:** 短手３判定ロジック修正（旧）。データ区分とコードを用いて「他の手術」を判定するように修正。関連テストコードも修正。パーサーの堅牢性に関する Issue #2 を作成。
+- **[2025-04-11]:** GitHub Actions リリースワークフロー修正。`release-drafter` を `git-cliff` に置き換え、関連エラーを修正。
+- **[2025-04-10]:** 短手３判定ロジック修正（加算除外）。
+- **[2025-04-08]:** 短手３判定ロジック修正（旧）。パーサー堅牢性 Issue #2 作成。
 - **[2025-04-06]:** CI/CD 推進計画 (Issue #1) 完了。CI ワークフロー実装、CD ワークフロー強化 (リリースノート自動生成)、関連ドキュメント更新。
 - **[2025-04-06]:** (旧) リリース自動化実装。単一HTML生成スクリプト、GitHub Actions ワークフロー導入。関連ドキュメント更新、バグ修正。(CI/CD 推進計画に統合)
 - **[2025-04-06]:** Deno 移行フェーズ8完了。Node.js 関連ファイル削除、Memory Bank 更新、README 更新。

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -68,8 +68,8 @@ graph LR
 - **Deno Test によるテスト:** ユニットテストと統合テストにより、コアロジックの正確性と安定性を担保。特に `validator` や `evaluator` のロジックはテストで品質を保証。
 - **`navigator.clipboard.writeText()` API 採用:** 廃止予定の `document.execCommand('copy')` を避け、モダンで信頼性の高いクリップボード操作を実現。
 - **GitHub Actions による CI/CD:**
-- **CI:** `main` ブランチへの push/pull request 時に Lint/Format/Test/Build を自動実行し、コード品質を維持 (`.github/workflows/ci.yml`)。
-- **CD:** タグプッシュ時にリリースノート自動生成 (`release-drafter` と Conventional Commits 規約を利用) とビルド成果物の GitHub Release への自動公開 (`.github/workflows/release.yml`)。
+  - **CI:** `main` ブランチへの push/pull request 時に Lint/Format/Test/Build を自動実行し、コード品質を維持 (`.github/workflows/ci.yml`)。
+  - **CD:** タグプッシュ時に **`git-cliff` (`orhun/git-cliff-action`)** を使用して Conventional Commits 規約に基づきリリースノートを自動生成し、ビルド成果物と共に GitHub Release へ自動公開 (`.github/workflows/release.yml`)。
 
 ## 3. デザインパターン
 

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -80,11 +80,11 @@ Deno 環境では、`npm install` のような明示的なインストールス�
     - トリガー: `main` ブランチへの push および pull request 作成・更新時。
     - 処理: Lint, Format チェック, テスト, ビルド確認を自動実行。
   - **CD:**
-    - 設定: `.github/workflows/release.yml`, `.github/release-drafter.yml`
+    - 設定: `.github/workflows/release.yml`, `cliff.toml`
     - トリガー: `v*.*.*` 形式のタグプッシュ。
     - 処理:
-      1. `release-drafter` を使用し、Conventional Commits 規約に基づいてリリースノートを自動生成し、ドラフトを作成。
-      2. `deno task release:build` を実行して単一HTMLファイルを生成。
-      3. 生成されたファイルを GitHub Release にアップロードし、ドラフトを公開。
+      1. `orhun/git-cliff-action@v3` を使用し、`cliff.toml` の設定と Conventional Commits 規約に基づいてリリースノートを生成 (`RELEASE_NOTES.md`)。
+      2. `deno task release:build` を実行して単一HTMLファイルを生成 (`dist/tanshu3.html`)。
+      3. `gh release create` コマンドを使用し、生成されたリリースノートとビルド成果物を含む GitHub Release を作成・公開。
 - **ステージング時チェック:**
   - Git フックは設定しない方針。


### PR DESCRIPTION
タグプッシュ時に発生していたリリース作成の問題を修正するため、release-drafter を git-cliff に置き換えました。git-cliff の設定を追加し、リリースワークフローを更新しました。関連する YAML 構文エラーも修正し、Memory Bank を更新しました。